### PR TITLE
升级，支持react 15.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ $ gulp server
 ## Usage
 
 ```js
-var Tooltip = require('uxcore-tooltip');
+import Tooltip from 'uxcore-tooltip';
+
 ReactDOM.render(
 	<Tooltip
 		placement="top"

--- a/demo/index.jsx
+++ b/demo/index.jsx
@@ -6,8 +6,8 @@
  * All rights reserved.
  */
 
-const React = require('react');
-const ReactDOM = require('react-dom');
-const Demo = require('./TooltipDemo');
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Demo from './TooltipDemo';
 
 ReactDOM.render(<Demo />, document.getElementById('UXCoreDemo'));

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <script src="./node_modules/console-polyfill/index.js"></script>
     <script src="./node_modules/es5-shim/es5-shim.min.js"></script>
     <script src="./node_modules/es5-shim/es5-sham.min.js"></script>
-    <script src="./node_modules/react/dist/react-with-addons.js"></script>
+    <script src="./node_modules/react/dist/react.js"></script>
     <script src="./node_modules/react-dom/dist/react-dom.js"></script>
     <script src="./dist/demo.js"></script>
 </body>

--- a/package.json
+++ b/package.json
@@ -1,55 +1,55 @@
 {
- "name": "uxcore-tooltip",
- "version": "0.4.5",
- "description": "uxcore-tooltip ui component for react",
- "main": "build/index.js",
- "scripts": {
-  "start": "uxcore-tools run start",
-  "server": "uxcore-tools run server",
-  "lint": "uxcore-tools run lint",
-  "build": "uxcore-tools run build",
-  "test": "uxcore-tools run test",
-  "coverage": "uxcore-tools run coverage",
-  "pub": "uxcore-tools run pub",
-  "dep": "uxcore-tools run dep",
-  "tnpm-dep": "uxcore-tools run tnpm-dep",
-  "chrome": "uxcore-tools run chrome",
-  "browsers": "uxcore-tools run browsers",
-  "saucelabs": "uxcore-tools run saucelabs",
-  "update": "uxcore-tools run update",
-  "tnpm-update": "uxcore-tools run tnpm-update"
- },
- "repository": {
-  "type": "git",
-  "url": "git@github.com:uxcore/uxcore-tooltip.git"
- },
- "bugs": {
-  "url": "http://github.com/uxcore/uxcore-tooltip/issues"
- },
- "keywords": [
-  "react",
-  "react-component",
-  "react-uxcore-tooltip",
-  "uxcore-tooltip"
- ],
- "devDependencies": {
-  "console-polyfill": "^0.2.2",
-  "es5-shim": "^4.5.8",
-  "expect.js": "~0.3.1",
-  "kuma-base": "1.x",
-  "react": "0.14.x",
-  "react-addons-test-utils": "0.14.x",
-  "react-dom": "0.14.x",
-  "uxcore-button": "~0.4.5",
-  "uxcore-kuma": "2.x",
-  "uxcore-tools": "0.2.x"
- },
- "dependencies": {
-  "classnames": "^2.1.2",
-  "object-assign": "^4.0.0",
-  "rc-tooltip": "~3.3.0"
- },
- "author": "vincent.bian",
- "contributors": [],
- "license": "MIT"
+  "name": "uxcore-tooltip",
+  "version": "0.4.6",
+  "description": "uxcore-tooltip ui component for react",
+  "main": "build/index.js",
+  "scripts": {
+    "start": "uxcore-tools run start",
+    "server": "uxcore-tools run server",
+    "lint": "uxcore-tools run lint",
+    "build": "uxcore-tools run build",
+    "test": "uxcore-tools run test",
+    "coverage": "uxcore-tools run coverage",
+    "pub": "uxcore-tools run pub",
+    "dep": "uxcore-tools run dep",
+    "tnpm-dep": "uxcore-tools run tnpm-dep",
+    "chrome": "uxcore-tools run chrome",
+    "browsers": "uxcore-tools run browsers",
+    "saucelabs": "uxcore-tools run saucelabs",
+    "update": "uxcore-tools run update",
+    "tnpm-update": "uxcore-tools run tnpm-update"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:uxcore/uxcore-tooltip.git"
+  },
+  "bugs": {
+    "url": "http://github.com/uxcore/uxcore-tooltip/issues"
+  },
+  "keywords": [
+    "react",
+    "react-component",
+    "react-uxcore-tooltip",
+    "uxcore-tooltip"
+  ],
+  "devDependencies": {
+    "console-polyfill": "^0.2.2",
+    "enzyme": "^3.0.0",
+    "enzyme-adapter-react-15": "^1.0.0",
+    "es5-shim": "^4.5.8",
+    "expect.js": "~0.3.1",
+    "kuma-base": "1.x",
+    "react": "15.x",
+    "react-dom": "15.x",
+    "react-test-renderer": "15.x",
+    "uxcore-button": "~0.4.5",
+    "uxcore-kuma": "*",
+    "uxcore-tools": "0.2.x"
+  },
+  "dependencies": {
+    "rc-tooltip": "~3.5.0"
+  },
+  "author": "vincent.bian",
+  "contributors": [],
+  "license": "MIT"
 }

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,11 +1,14 @@
 import RcTooltip from 'rc-tooltip';
 import assign from 'object-assign';
 
-export default class Tooltip extends RcTooltip {}
-Tooltip.displayName = 'uxcore-tooltip';
-Tooltip.propTypes = RcTooltip.propTypes;
-
-Tooltip.defaultProps = assign(RcTooltip.defaultProps, {
-  prefixCls: 'kuma-tooltip',
-  transitionName: 'tip-slide',
-});
+export default class Tooltip extends RcTooltip {
+    static displayName = 'uxcore-tooltip'
+    static propTypes = {
+        ...RcTooltip.propTypes,
+    }
+    static defaultProps = {
+        ...RcTooltip.defaultProps,
+        prefixCls: 'kuma-tooltip',
+        transitionName: 'tip-slide',
+    }
+}

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,5 +1,4 @@
 import RcTooltip from 'rc-tooltip';
-import assign from 'object-assign';
 
 export default class Tooltip extends RcTooltip {
     static displayName = 'uxcore-tooltip'

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,6 @@
  * All rights reserved.
  */
 
-module.exports = require('./Tooltip');
+import Tooltip from './Tooltip';
+
+export default Tooltip;


### PR DESCRIPTION
改动点：
1. 按照升级文档说明运行指令`yo uxcore:upgrade`升级package.json
1. 更新rc-tooltip版本从\~3.3.0更新到~3.5.0，去除PropTypes警告
1. 使用ES6语法替代object-assign
1. 使用ES6的static语法设置displayName、propTypes、defaultProps的赋值方式