### PR TITLE
兼容React16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ spm_modules
 dist
 build
 assets/**/*.css
+coverage
+package-lock.json

--- a/index.html
+++ b/index.html
@@ -1,18 +1,20 @@
 <!DOCTYPE html>
 <html>
+
 <head>
     <title>uxcore-tooltip</title>
     <link rel="stylesheet" type="text/css" href="//alinw.alicdn.com/??platform/common/s/1.1/global/global.css">
     <link rel="stylesheet" href="./node_modules/uxcore-kuma/dist/orange.css">
     <link rel="stylesheet" href="./dist/demo.css">
 </head>
+
 <body>
     <div id="UXCoreDemo"></div>
     <script src="./node_modules/console-polyfill/index.js"></script>
-    <script src="./node_modules/es5-shim/es5-shim.min.js"></script>
-    <script src="./node_modules/es5-shim/es5-sham.min.js"></script>
-    <script src="./node_modules/react/dist/react.js"></script>
-    <script src="./node_modules/react-dom/dist/react-dom.js"></script>
+    <script src="./node_modules/babel-polyfill/dist/polyfill.min.js"></script>
+    <script src="./node_modules/react/umd/react.development.js"></script>
+    <script src="./node_modules/react-dom/umd/react-dom.development.js"></script>
     <script src="./dist/demo.js"></script>
 </body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -33,21 +33,21 @@
   "uxcore-tooltip"
  ],
  "devDependencies": {
+  "babel-polyfill": "6.x",
   "console-polyfill": "^0.2.2",
-  "enzyme": "^3.0.0",
-  "enzyme-adapter-react-15": "^1.0.0",
-  "es5-shim": "^4.5.8",
+  "enzyme": "^3.3.0",
+  "enzyme-adapter-react-16": "1.x",
   "expect.js": "~0.3.1",
   "kuma-base": "1.x",
-  "react": "15.x",
-  "react-dom": "15.x",
-  "react-test-renderer": "15.x",
+  "react": "16.x",
+  "react-dom": "16.x",
+  "react-test-renderer": "16.x",
   "uxcore-button": "~0.4.5",
   "uxcore-kuma": "*",
-  "uxcore-tools": "0.2.x"
+  "uxcore-tools": "0.3.x"
  },
  "dependencies": {
-  "rc-tooltip": "^3.0.0"
+  "rc-tooltip": "^3.7.x"
  },
  "author": "vincent.bian",
  "contributors": [],

--- a/package.json
+++ b/package.json
@@ -1,55 +1,55 @@
 {
- "name": "uxcore-tooltip",
- "version": "0.4.10",
- "description": "uxcore-tooltip ui component for react",
- "main": "build/index.js",
- "scripts": {
-  "start": "uxcore-tools run start",
-  "server": "uxcore-tools run server",
-  "lint": "uxcore-tools run lint",
-  "build": "uxcore-tools run build",
-  "test": "uxcore-tools run test",
-  "coverage": "uxcore-tools run coverage",
-  "pub": "uxcore-tools run pub",
-  "dep": "uxcore-tools run dep",
-  "tnpm-dep": "uxcore-tools run tnpm-dep",
-  "chrome": "uxcore-tools run chrome",
-  "browsers": "uxcore-tools run browsers",
-  "saucelabs": "uxcore-tools run saucelabs",
-  "update": "uxcore-tools run update",
-  "tnpm-update": "uxcore-tools run tnpm-update"
- },
- "repository": {
-  "type": "git",
-  "url": "git@github.com:uxcore/uxcore-tooltip.git"
- },
- "bugs": {
-  "url": "http://github.com/uxcore/uxcore-tooltip/issues"
- },
- "keywords": [
-  "react",
-  "react-component",
-  "react-uxcore-tooltip",
-  "uxcore-tooltip"
- ],
- "devDependencies": {
-  "babel-polyfill": "6.x",
-  "console-polyfill": "^0.2.2",
-  "enzyme": "^3.3.0",
-  "enzyme-adapter-react-16": "1.x",
-  "expect.js": "~0.3.1",
-  "kuma-base": "1.x",
-  "react": "16.x",
-  "react-dom": "16.x",
-  "react-test-renderer": "16.x",
-  "uxcore-button": "~0.4.5",
-  "uxcore-kuma": "*",
-  "uxcore-tools": "0.3.x"
- },
- "dependencies": {
-  "rc-tooltip": "^3.7.x"
- },
- "author": "vincent.bian",
- "contributors": [],
- "license": "MIT"
+  "name": "uxcore-tooltip",
+  "version": "0.4.10",
+  "description": "uxcore-tooltip ui component for react",
+  "main": "build/index.js",
+  "scripts": {
+    "start": "uxcore-tools run start",
+    "server": "uxcore-tools run server",
+    "lint": "uxcore-tools run lint",
+    "build": "uxcore-tools run build",
+    "test": "uxcore-tools run test",
+    "coverage": "uxcore-tools run coverage",
+    "pub": "uxcore-tools run pub",
+    "dep": "uxcore-tools run dep",
+    "tnpm-dep": "uxcore-tools run tnpm-dep",
+    "chrome": "uxcore-tools run chrome",
+    "browsers": "uxcore-tools run browsers",
+    "saucelabs": "uxcore-tools run saucelabs",
+    "update": "uxcore-tools run update",
+    "tnpm-update": "uxcore-tools run tnpm-update"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:uxcore/uxcore-tooltip.git"
+  },
+  "bugs": {
+    "url": "http://github.com/uxcore/uxcore-tooltip/issues"
+  },
+  "keywords": [
+    "react",
+    "react-component",
+    "react-uxcore-tooltip",
+    "uxcore-tooltip"
+  ],
+  "devDependencies": {
+    "babel-polyfill": "6.x",
+    "console-polyfill": "^0.2.2",
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "1.x",
+    "expect.js": "~0.3.1",
+    "kuma-base": "1.x",
+    "react": "16.x",
+    "react-dom": "16.x",
+    "react-test-renderer": "16.x",
+    "uxcore-button": "~0.4.5",
+    "uxcore-kuma": "*",
+    "uxcore-tools": "0.3.x"
+  },
+  "dependencies": {
+    "rc-tooltip": "^3.7.0"
+  },
+  "author": "vincent.bian",
+  "contributors": [],
+  "license": "MIT"
 }

--- a/tests/Tooltip.spec.js
+++ b/tests/Tooltip.spec.js
@@ -1,17 +1,25 @@
-import expect from 'expect.js';
-import React from 'react';
-import ReactDOM from 'react-dom';
-import TestUtils, { Simulate } from 'react-dom/test-utils';
-import Enzyme, { mount } from 'enzyme'
-import Adapter from 'enzyme-adapter-react-15'
-import Tooltip from '../src';
+import expect from "expect.js";
+import React from "react";
+import ReactDOM from "react-dom";
+import TestUtils, { Simulate } from "react-dom/test-utils";
+import Enzyme, { mount } from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+import Tooltip from "../src";
 
 Enzyme.configure({
-    adapter: new Adapter()
-})
+  adapter: new Adapter()
+});
 
-describe('Tooltip', () => {
-    it('render', () => {
-        mount(<Tooltip placement="left" trigger={['click']} overlay={<span>tooltip</span>}><a href='#'>hover</a></Tooltip>)
-    })
+describe("Tooltip", () => {
+  it("render", () => {
+    mount(
+      <Tooltip
+        placement="left"
+        trigger={["click"]}
+        overlay={<span>tooltip</span>}
+      >
+        <a href="#">hover</a>
+      </Tooltip>
+    );
+  });
 });


### PR DESCRIPTION
- 根据升级文档，使用最新版本uxcore-tools运行upgrade16，清除控制台warnings
- rc-tooltip依赖升级到^3.7.0